### PR TITLE
Revert some version.rb back to module

### DIFF
--- a/merb-assets/lib/merb-assets/version.rb
+++ b/merb-assets/lib/merb-assets/version.rb
@@ -1,5 +1,5 @@
 module Merb
-  class Assets
+  module Assets
     VERSION = '1.2.0'.freeze
   end
 end

--- a/merb-cache/lib/merb-cache/version.rb
+++ b/merb-cache/lib/merb-cache/version.rb
@@ -1,5 +1,5 @@
 module Merb
-  class Cache
+  module Cache
     VERSION = '1.2.0'.freeze
   end
 end

--- a/merb-gen/lib/merb-gen/version.rb
+++ b/merb-gen/lib/merb-gen/version.rb
@@ -1,5 +1,5 @@
 module Merb
-  class Generators
+  module Generators
 
     VERSION = '1.2.0'.freeze
 

--- a/merb-helpers/lib/merb-helpers/version.rb
+++ b/merb-helpers/lib/merb-helpers/version.rb
@@ -1,5 +1,5 @@
 module Merb
-  class Helpers
+  module Helpers
     VERSION = '1.2.0'.freeze
   end
 end

--- a/merb-param-protection/lib/merb-param-protection/version.rb
+++ b/merb-param-protection/lib/merb-param-protection/version.rb
@@ -1,5 +1,5 @@
 module Merb
-  class ParamProtection
+  module ParamProtection
     VERSION = '1.2.0'.freeze
   end
 end

--- a/merb-slices/lib/merb-slices/version.rb
+++ b/merb-slices/lib/merb-slices/version.rb
@@ -1,5 +1,5 @@
 module Merb
-  class Slices
+  module Slices
     VERSION = '1.2.0'.freeze
   end
 end


### PR DESCRIPTION
My last fix helped me with my trouble spot, merb-mailer, but broke most of the other plugins. Went through and checked what the gem defined and fixed version.rb as applicable.
