### PR TITLE
1.1.x: fix LoadError cannot be caught with default rescue.

### DIFF
--- a/merb-action-args/lib/merb-action-args/vm_args.rb
+++ b/merb-action-args/lib/merb-action-args/vm_args.rb
@@ -1,6 +1,6 @@
 begin
   require "methopara"
-rescue
+rescue LoadError
   puts "Make sure you have methopara http://github.com/genki/methopara installed if you want to use action args on Ruby 1.9"
 end
 


### PR DESCRIPTION
- specify error type 'LoadError' for rescue.
