### PR TITLE
Extlib security patch

### DIFF
--- a/merb-core/Gemfile
+++ b/merb-core/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'extlib', '>= 0.9.13'
+gem 'extlib', '>= 0.9.17'
 gem 'erubis'
 gem 'rake'
 gem 'rack'


### PR DESCRIPTION
There is a problem with XML type request to merb that contain YAML. It is fixed in new version of extlib.
